### PR TITLE
Check package can be built

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,3 +21,6 @@ jobs:
         run: npm ci
       - name: Test
         run: npm run test
+      - name: Build
+        # This checks that the package can be built
+        run: npm run build


### PR DESCRIPTION
We had a release fail in `main` since the package wasn't buildable. This will catch this earlier. 