### PR TITLE
Allow consumers to pass arbitrary api urls

### DIFF
--- a/.changeset/cool-dancers-doubt.md
+++ b/.changeset/cool-dancers-doubt.md
@@ -2,4 +2,4 @@
 '@team-plain/typescript-sdk': minor
 ---
 
-Allow configuration of api url
+Support providing a custom API endpoint for testing internally at Plain against staging and other environments.

--- a/.changeset/cool-dancers-doubt.md
+++ b/.changeset/cool-dancers-doubt.md
@@ -1,0 +1,5 @@
+---
+'@team-plain/typescript-sdk': minor
+---
+
+Allow configuration of api url

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,9 +47,10 @@ function unwrapData<T, X>(
 export class PlainClient {
   #ctx: Context;
 
-  constructor(options: { apiKey: string }) {
+  constructor(options: { apiKey: string; apiUrl?: string }) {
     this.#ctx = {
       apiKey: options.apiKey,
+      apiUrl: options.apiUrl,
     };
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,4 @@
 export type Context = {
   apiKey: string;
+  apiUrl?: string;
 };

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,8 @@ import type { Context } from './context';
 import type { PlainSDKError } from './error';
 import { getMutationErrorFromResponse, isPlainGraphQLResponse } from './graphql-utlities';
 
+const defaultUrl = 'https://core-api.uk.plain.com/graphql/v1';
+
 export async function request<Query, Variables>(
   ctx: Context,
   args: {
@@ -20,7 +22,7 @@ export async function request<Query, Variables>(
       Authorization: `Bearer ${ctx.apiKey}`,
     };
 
-    const url = 'https://core-api.uk.plain.com/graphql/v1';
+    const url = ctx.apiUrl || defaultUrl;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { data: res } = await axios.post(

--- a/src/tests/raw-request.test.ts
+++ b/src/tests/raw-request.test.ts
@@ -36,6 +36,29 @@ describe('raw request', () => {
     scope.done();
   });
 
+  test('uses custom url if provided', async () => {
+    const query = '';
+    const variables = {};
+    const scope = nock('https://core-api.uk.getresolve.io')
+      .post('/graphql/v1', {
+        query,
+        variables,
+      })
+      .reply(200, {});
+
+    const client = new PlainClient({
+      apiKey: 'abc',
+      apiUrl: 'https://core-api.uk.getresolve.io/graphql/v1',
+    });
+
+    await client.rawRequest({
+      query,
+      variables,
+    });
+
+    scope.done();
+  });
+
   test('handles graphql errors', async () => {
     const graphqlErrors: PlainGraphQLError[] = [
       {


### PR DESCRIPTION
This is used internally for hitting our development/staging environments