### PR TITLE
Allow other package managers besides npm

### DIFF
--- a/.changeset/tidy-weeks-deliver.md
+++ b/.changeset/tidy-weeks-deliver.md
@@ -1,0 +1,5 @@
+---
+'@team-plain/typescript-sdk': patch
+---
+
+Allow other package managers besides pnpm

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "lint:prettier": "prettier --config=.prettierrc --ignore-path=.prettierignore --check '**/*.{ts,tsx,gql,js}'",
     "test": "vitest",
     "changeset": "changeset",
-    "release": "npm whoami && npm run build && changeset publish",
-    "preinstall": "npx only-allow pnpm"
+    "release": "npm whoami && npm run build && changeset publish"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
New copy of https://github.com/team-plain/typescript-sdk/pull/60 with changeset