### PR TITLE
Allow missing path in graphql errors

### DIFF
--- a/src/graphql-utlities.ts
+++ b/src/graphql-utlities.ts
@@ -9,19 +9,29 @@ import {
 export const PlainGraphQLError = z.object({
   message: z.string(),
   locations: z.array(z.object({ line: z.number(), column: z.number() })),
-  path: z.array(z.union([z.string(), z.number()])),
+  path: z.array(z.union([z.string(), z.number()])).optional(),
   extensions: z.object({ code: z.string() }),
 });
 export type PlainGraphQLError = z.infer<typeof PlainGraphQLError>;
 
-export const PlainGraphQLResponse = z.object({
+const PlainSuccessfulGraphQLResponse = z.object({
   data: z.unknown(),
-  errors: z.array(PlainGraphQLError).optional(),
 });
-export type PlainGraphQLResponse = z.infer<typeof PlainGraphQLResponse>;
 
-export function isPlainGraphQLResponse(x: unknown): x is PlainGraphQLResponse {
-  return PlainGraphQLResponse.safeParse(x).success;
+export function isPlainSuccessfulGraphQLResponse(
+  x: unknown
+): x is z.infer<typeof PlainSuccessfulGraphQLResponse> {
+  return PlainSuccessfulGraphQLResponse.safeParse(x).success;
+}
+
+const PlainFailedGraphQLResponse = z.object({
+  errors: z.array(PlainGraphQLError),
+});
+
+export function isPlainFailedGraphQLResponse(
+  x: unknown
+): x is z.infer<typeof PlainFailedGraphQLResponse> {
+  return PlainFailedGraphQLResponse.safeParse(x).success;
 }
 
 const PlainMutationResponse = z.record(
@@ -42,9 +52,8 @@ const PlainMutationResponse = z.record(
     }),
   })
 );
-type PlainMutationResponse = z.infer<typeof PlainMutationResponse>;
 
-function isPlainMutationResponse(x: unknown): x is PlainMutationResponse {
+function isPlainMutationResponse(x: unknown): x is z.infer<typeof PlainMutationResponse> {
   return PlainMutationResponse.safeParse(x).success;
 }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,7 +4,11 @@ import { print } from 'graphql';
 
 import type { Context } from './context';
 import type { PlainSDKError } from './error';
-import { getMutationErrorFromResponse, isPlainGraphQLResponse } from './graphql-utlities';
+import {
+  getMutationErrorFromResponse,
+  isPlainFailedGraphQLResponse,
+  isPlainSuccessfulGraphQLResponse,
+} from './graphql-utlities';
 import type { Result } from './result';
 
 const defaultUrl = 'https://core-api.uk.plain.com/graphql/v1';
@@ -45,7 +49,7 @@ export async function request<Query, Variables>(
       }
     );
 
-    if (!isPlainGraphQLResponse(res)) {
+    if (!isPlainSuccessfulGraphQLResponse(res)) {
       throw new Error('Unexpected response received');
     }
 
@@ -88,11 +92,11 @@ export async function request<Query, Variables>(
           };
         }
 
-        if (err.response.status === 400 && isPlainGraphQLResponse(err.response.data)) {
+        if (err.response.status === 400 && isPlainFailedGraphQLResponse(err.response.data)) {
           return {
             error: {
               type: 'bad_request',
-              message: 'Missing or invalid arguments provided.',
+              message: 'Malformed query, missing or invalid arguments provided.',
               graphqlErrors: err.response.data.errors || [],
               requestId: getRequestId(err.response.headers),
             },

--- a/src/tests/query.test.ts
+++ b/src/tests/query.test.ts
@@ -110,7 +110,7 @@ describe('query test - customer by id', () => {
 
     const err: PlainSDKError = {
       type: 'bad_request',
-      message: 'Missing or invalid arguments provided.',
+      message: 'Malformed query, missing or invalid arguments provided.',
       graphqlErrors,
       requestId: 'req_1',
     };


### PR DESCRIPTION
`path` might not be present in the resulting errors, which means we were treating some 400 errors are 'unknown'.