### PR TITLE
P-5779: Updated public fragment types

### DIFF
--- a/.changeset/perfect-singers-grow.md
+++ b/.changeset/perfect-singers-grow.md
@@ -1,0 +1,5 @@
+---
+'@team-plain/typescript-sdk': minor
+---
+
+Export Public fragment types, which flatten connection object edges into arrays

--- a/src/client.ts
+++ b/src/client.ts
@@ -58,9 +58,9 @@ import {
 import { request } from './request';
 import type { Result } from './result';
 
-type SDKResult<T> = Promise<Result<Transform<T>, PlainSDKError>>;
+type SDKResult<T> = Promise<Result<Public<T>, PlainSDKError>>;
 
-// Transform takes a GraphQL Fragment and transforms it into a type in which
+// Public takes a GraphQL Fragment and transforms it into a type in which
 // all of its connection-like fields (e.g. fields which have an `edges`) property
 // are flattened into an array. For example:
 //
@@ -72,17 +72,17 @@ type SDKResult<T> = Promise<Result<Transform<T>, PlainSDKError>>;
 //     }
 // }
 //
-// When we apply Transform to it, we get:
+// When we apply Public to it, we get:
 //
-// type Transform<Fragment> = {
+// type Public<Fragment> = {
 // {
 //     customerGroupMemberships: Array<CustomerGroupMembershipPartsFragment>
 // }
 //
-type Transform<T> = T extends { edges: Array<{ node: infer E }> }
-  ? Array<Transform<E>>
+export type Public<T> = T extends { edges: Array<{ node: infer E }> }
+  ? Array<Public<E>>
   : T extends object
-  ? { [K in keyof T]: Transform<T[K]> }
+  ? { [K in keyof T]: Public<T[K]> }
   : T;
 
 function nonNullable<T>(x: T | null | undefined): T {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,34 @@
 /* eslint-disable simple-import-sort/exports */
 
+import type { Public } from './client';
+import {
+  type ActorPartsFragment as OriginalActorPartsFragment,
+  type AttachmentPartsFragment as OriginalAttachmentPartsFragment,
+  type CustomerActorPartsFragment as OriginalCustomerActorPartsFragment,
+  type CustomerEventPartsFragment as OriginalCustomerEventPartsFragment,
+  type CustomerGroupMembershipPartsFragment as OriginalCustomerGroupMembershipPartsFragment,
+  type CustomerGroupPartsFragment as OriginalCustomerGroupPartsFragment,
+  type CustomerPartsFragment as OriginalCustomerPartsFragment,
+  type DateTimePartsFragment as OriginalDateTimePartsFragment,
+  type DeletedCustomerActorPartsFragment as OriginalDeletedCustomerActorPartsFragment,
+  type EmailActorPartsFragment as OriginalEmailActorPartsFragment,
+  type EmailParticipantPartsFragment as OriginalEmailParticipantPartsFragment,
+  type EmailPartsFragment as OriginalEmailPartsFragment,
+  type FileSizePartsFragment as OriginalFileSizePartsFragment,
+  type InternalActorPartsFragment as OriginalInternalActorPartsFragment,
+  type LabelPartsFragment as OriginalLabelPartsFragment,
+  type LabelTypePartsFragment as OriginalLabelTypePartsFragment,
+  type MachineUserActorPartsFragment as OriginalMachineUserActorPartsFragment,
+  type MutationErrorPartsFragment as OriginalMutationErrorPartsFragment,
+  type PageInfoPartsFragment as OriginalPageInfoPartsFragment,
+  type SystemActorPartsFragment as OriginalSystemActorPartsFragment,
+  type ThreadEventPartsFragment as OriginalThreadEventPartsFragment,
+  type ThreadPartsFragment as OriginalThreadPartsFragment,
+  type TimelineEntryPartsFragment as OriginalTimelineEntryPartsFragment,
+  type UserActorPartsFragment as OriginalUserActorPartsFragment,
+  type WorkspacePartsFragment as OriginalWorkspacePartsFragment,
+} from './graphql/types';
+
 export { PlainClient } from './client';
 
 export { uiComponent } from './ui-components';
@@ -23,6 +52,34 @@ export {
   ThreadsSortField,
   UserStatus,
 } from './graphql/types';
+
+// Export *Public* fragment types
+export type ActorPartsFragment = Public<OriginalActorPartsFragment>;
+export type AttachmentPartsFragment = Public<OriginalAttachmentPartsFragment>;
+export type CustomerActorPartsFragment = Public<OriginalCustomerActorPartsFragment>;
+export type CustomerGroupMembershipPartsFragment =
+  Public<OriginalCustomerGroupMembershipPartsFragment>;
+export type CustomerGroupPartsFragment = Public<OriginalCustomerGroupPartsFragment>;
+export type CustomerPartsFragment = Public<OriginalCustomerPartsFragment>;
+export type DateTimePartsFragment = Public<OriginalDateTimePartsFragment>;
+export type DeletedCustomerActorPartsFragment = Public<OriginalDeletedCustomerActorPartsFragment>;
+export type EmailActorPartsFragment = Public<OriginalEmailActorPartsFragment>;
+export type EmailParticipantPartsFragment = Public<OriginalEmailParticipantPartsFragment>;
+export type EmailPartsFragment = Public<OriginalEmailPartsFragment>;
+export type FileSizePartsFragment = Public<OriginalFileSizePartsFragment>;
+export type InternalActorPartsFragment = Public<OriginalInternalActorPartsFragment>;
+export type MachineUserActorPartsFragment = Public<OriginalMachineUserActorPartsFragment>;
+export type MutationErrorPartsFragment = Public<OriginalMutationErrorPartsFragment>;
+export type PageInfoPartsFragment = Public<OriginalPageInfoPartsFragment>;
+export type SystemActorPartsFragment = Public<OriginalSystemActorPartsFragment>;
+export type TimelineEntryPartsFragment = Public<OriginalTimelineEntryPartsFragment>;
+export type UserActorPartsFragment = Public<OriginalUserActorPartsFragment>;
+export type WorkspacePartsFragment = Public<OriginalWorkspacePartsFragment>;
+export type ThreadPartsFragment = Public<OriginalThreadPartsFragment>;
+export type LabelTypePartsFragment = Public<OriginalLabelTypePartsFragment>;
+export type LabelPartsFragment = Public<OriginalLabelPartsFragment>;
+export type CustomerEventPartsFragment = Public<OriginalCustomerEventPartsFragment>;
+export type ThreadEventPartsFragment = Public<OriginalThreadEventPartsFragment>;
 
 export type {
   // Query arguments
@@ -53,33 +110,6 @@ export type {
   UpdateCustomerCardConfigInput,
   UpsertCustomerInput,
   UpsertCustomTimelineEntryInput,
-
-  // Fragment types
-  ActorPartsFragment,
-  AttachmentPartsFragment,
-  CustomerActorPartsFragment,
-  CustomerGroupMembershipPartsFragment,
-  CustomerGroupPartsFragment,
-  CustomerPartsFragment,
-  DateTimePartsFragment,
-  DeletedCustomerActorPartsFragment,
-  EmailActorPartsFragment,
-  EmailParticipantPartsFragment,
-  EmailPartsFragment,
-  FileSizePartsFragment,
-  InternalActorPartsFragment,
-  MachineUserActorPartsFragment,
-  MutationErrorPartsFragment,
-  PageInfoPartsFragment,
-  SystemActorPartsFragment,
-  TimelineEntryPartsFragment,
-  UserActorPartsFragment,
-  WorkspacePartsFragment,
-  ThreadPartsFragment,
-  LabelTypePartsFragment,
-  LabelPartsFragment,
-  CustomerEventPartsFragment,
-  ThreadEventPartsFragment,
 } from './graphql/types';
 
 export type {


### PR DESCRIPTION
We should either:
- export different, simpler types (derived from Fragments)
- auto-generate these public types

But for now this should be OK.