### PR TITLE
P-7468: Fixed webhook schema

### DIFF
--- a/.changeset/gorgeous-experts-sniff.md
+++ b/.changeset/gorgeous-experts-sniff.md
@@ -1,0 +1,5 @@
+---
+'@team-plain/typescript-sdk-dev': minor
+---
+
+Fixed webhook schema definition

--- a/src/webhooks/webhook-schema.json
+++ b/src/webhooks/webhook-schema.json
@@ -517,7 +517,7 @@
         },
         "color": {
           "type": "string",
-          "pattern": "^#([a-f0-9]{3,4}|[a-f0-9]{4}(?:[a-f0-9]{2}){1,2})\\b$"
+          "pattern": "^#([a-fA-F0-9]{3,4}|[a-fA-F0-9]{4}(?:[a-fA-F0-9]{2}){1,2})$"
         },
         "createdAt": {
           "$ref": "#/definitions/datetime"


### PR DESCRIPTION
People with customer groups containing hex colors currently can't validate webhook payloads.